### PR TITLE
Naming conventions are not supported as gs-spring-boot

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -8,12 +8,7 @@
     <groupId>org.springframework</groupId>
     <artifactId>gs-spring-boot</artifactId>
     <version>0.1.0</version>
-    
-   <build>
-     <finalName>app</finalName> 
-   </build>
-
-    
+     
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
@@ -45,6 +40,7 @@
     </properties>
 
     <build>
+         <finalName>app</finalName> 
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -6,7 +8,12 @@
     <groupId>org.springframework</groupId>
     <artifactId>gs-spring-boot</artifactId>
     <version>0.1.0</version>
+    
+   <build>
+     <finalName>app</finalName> 
+   </build>
 
+    
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>


### PR DESCRIPTION
After successful CICD, Hello Message was not displayed, CI pipe line was producing the build with sg-spring-boot.jar , this format no longer supported, it should be App.jar  